### PR TITLE
fix headless option on chromedriver not working if other options are set

### DIFF
--- a/webdriver/chromedriver.nim
+++ b/webdriver/chromedriver.nim
@@ -24,11 +24,10 @@ method close*(d: ChromeDriver) {.async.} =
 
 method adjustSessionArguments*(d: ChromeDriver, args: JsonNode, options = %*{}, headless: bool) =
   if headless:
-    args["capabilities"]["alwaysMatch"]["goog:chromeOptions"] = %*{
-      "args": [
-        "-headless"
-      ]
-    }
+    if options.hasKey("args"):
+      options["args"].add(%"-headless")
+    else:
+      options["args"] = %["-headless"]
 
   if options != %*{}:
     args["capabilities"]["alwaysMatch"]["goog:chromeOptions"] = options


### PR DESCRIPTION
The headless option in chromedriver doesn't work if you also pass in any other options since options just overwrites all the args. This instead adds "-headless" to options["args"] so nothing is overwritten.